### PR TITLE
Interpolate lazy nodes from class attributes and methods by parsing AST

### DIFF
--- a/tributary/incubating/ast_experiments.py
+++ b/tributary/incubating/ast_experiments.py
@@ -1,11 +1,27 @@
-import ast
-import inspect
-import textwrap
+import random
 
 import tributary.lazy as t
 
+from tributary.parser import (
+    parseASTForMethod,
+    pprintAst,
+    getClassAttributesUsedInMethod,
+    addAttributeDepsToMethodSignature,
+    Transformer,
+    pprintCode,
+)
 
 blerg = t.Node(value=5)
+
+
+class Func4(t.LazyGraph):
+    @t.node()
+    def func1(self):
+        return self.func2() + 1
+
+    @t.node(dynamic=True)
+    def func2(self):
+        return random.random()
 
 
 class Func5(t.LazyGraph):
@@ -21,40 +37,15 @@ class Func5(t.LazyGraph):
         return self.x() | self.y() | blerg
 
     def zz(self):
-        return self.x | self.y() | blerg
+        return self.x | self.y()
 
     @t.node()
     def y(self):
         return 10
 
 
-source = inspect.getsource(Func5.zz)
-root = ast.parse(textwrap.dedent(source)).body[0]
-
-print(ast.dump(root, indent=4))
-
-
-def isClassAttribute(node):
-    # self.aNode()
-    if (
-        isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and node.func.value.id == "self"
-    ):
-        return node.func.attr
-    # self.aNode
-    elif isinstance(node, ast.Attribute) and node.value.id == "self":
-        return node.attr
-
-
-def getClassAttributesUsedInMethod(root):
-    attribute_deps = []
-    for node in ast.walk(root):
-        attr = isClassAttribute(node)
-        if attr:
-            attribute_deps.append(attr)
-    return attribute_deps
-
+root, mod = parseASTForMethod(Func5.zz)
+pprintAst(root)
 
 ads = getClassAttributesUsedInMethod(root)
 # print("attribute deps:", ads)
@@ -66,39 +57,11 @@ ads = getClassAttributesUsedInMethod(root)
 # print(root.args.defaults)
 # print("***")
 
-
-# append attribute args to method definition
-def addAttributeDepsToMethodSignature(root, attribute_deps):
-    for attribute_dep in attribute_deps:
-        append = True
-
-        for meth_arg in root.args.args:
-            if meth_arg.arg == attribute_dep:
-                append = False
-
-        if append:
-            root.args.args.append(ast.arg(attribute_dep))
-
-
 addAttributeDepsToMethodSignature(root, ads)
 
-
-class Transformer(ast.NodeTransformer):
-    def generic_visit(self, node):
-        # Need to call super() in any case to visit child nodes of the current one.
-        super().generic_visit(node)
-
-        # if isClassAttribute(node):
-        #     return ast.Attribute()
-        # Attribute(
-        #                 value=Name(id='self', ctx=Load()),
-        #                 attr='x',
-        #                 ctx=Load()),
-        return node
-
-
-print(ast.unparse(Transformer().visit(root)))
-
+new_root = Transformer().visit(root)
+mod.body[0] = new_root
+pprintCode(mod)
 
 # names = sorted({node.id for node in ast.walk(root) if isinstance(node, ast.Name)})
 # print(names)

--- a/tributary/incubating/ast_experiments.py
+++ b/tributary/incubating/ast_experiments.py
@@ -35,19 +35,14 @@ print(ast.dump(root, indent=4))
 
 
 def isClassAttribute(node):
-    # right=Call(
-    #     func=Attribute(
-    #         value=Name(id='self', ctx=Load()),
-    #         attr='y',
-    #         ctx=Load()),
-    #     args=[],
-    # keywords=[])),
+    # self.aNode()
     if (
         isinstance(node, ast.Call)
         and isinstance(node.func, ast.Attribute)
         and node.func.value.id == "self"
     ):
         return node.func.attr
+    # self.aNode
     elif isinstance(node, ast.Attribute) and node.value.id == "self":
         return node.attr
 

--- a/tributary/lazy/base.py
+++ b/tributary/lazy/base.py
@@ -1,2 +1,3 @@
 from .graph import LazyGraph
-from .node import Node, node
+from .node import Node
+from .decorator import node

--- a/tributary/lazy/decorator.py
+++ b/tributary/lazy/decorator.py
@@ -1,6 +1,6 @@
 from .node import Node
 from ..utils import _either_type
-from ..parser import (
+from ..parser import (  # noqa: F401
     pprintCode,
     pprintAst,
     parseASTForMethod,

--- a/tributary/lazy/decorator.py
+++ b/tributary/lazy/decorator.py
@@ -1,0 +1,55 @@
+from .node import Node
+from ..utils import _either_type
+from ..parser import (
+    pprintCode,
+    pprintAst,
+    parseASTForMethod,
+    getClassAttributesUsedInMethod,
+    addAttributeDepsToMethodSignature,
+    Transformer,
+)
+
+
+@_either_type
+def node(meth, dynamic=False):
+    """Convert a method into a lazy node"""
+
+    # parse out function
+    root, mod = parseASTForMethod(meth)
+
+    # grab accessed attributes
+    ads = getClassAttributesUsedInMethod(root)
+
+    # # add them to signature
+    # addAttributeDepsToMethodSignature(root, ads)
+
+    # # modify
+    # new_root = Transformer().visit(root)
+
+    # # remove decorators
+    # new_root.decorator_list = []
+
+    # # replace in module
+    # mod.body[0] = new_root
+
+    # # pprintAst(new_root)
+    # # pprintCode(mod)
+    # meth = exec(compile(mod, meth.__code__.co_filename, "exec"), meth.__globals__)
+    # print(type(meth))
+    # import ipdb; ipdb.set_trace()
+
+    new_node = Node(value=meth)
+    new_node._nodes_to_bind = ads
+
+    # if new_node._callable_is_method:
+    #     ret = lambda self, *args, **kwargs: new_node._bind(  # noqa: E731
+    #         self, *args, **kwargs
+    #     )
+    # else:
+    #     ret = lambda *args, **kwargs: new_node._bind(  # noqa: E731
+    #         None, *args, **kwargs
+    #     )
+    # ret._node_wrapper = new_node
+    # return ret
+
+    return new_node

--- a/tributary/lazy/graph.py
+++ b/tributary/lazy/graph.py
@@ -20,11 +20,17 @@ class LazyGraph(object):
 
                     for node in nodes_to_bind:
                         if not hasattr(self, node):
-                            raise TributaryException("Error binding dependency {} to node {} - make sure to super() after all nodes are defined".format(node, meth))
+                            raise TributaryException(
+                                "Error binding dependency {} to node {} - make sure to super() after all nodes are defined".format(
+                                    node, meth
+                                )
+                            )
 
                         node_to_bind = getattr(self, node)
                         if isinstance(node_to_bind, Node):
-                            meth << getattr(self, node)                     
+                            meth << getattr(self, node)
+
+                print(meth._name, meth._parameters, meth.upstream())
 
     def node(self, name, readonly=False, nullable=True, value=None):  # noqa: F811
         """method to create a lazy node attached to a graph.

--- a/tributary/lazy/graph.py
+++ b/tributary/lazy/graph.py
@@ -14,34 +14,17 @@ class LazyGraph(object):
             if isinstance(meth, Node):
                 meth._self_reference = self
 
-            elif hasattr(meth, "_node_wrapper"):
-                node = meth._node_wrapper
-                if node is None:
-                    continue
-                # FIXME redo
-                # modify in place in case used elsewhere
-                # for i, arg in enumerate(node._callable_args):
-                #     if not isinstance(arg, Node):
-                #         replace = getattr(self, arg)
-                #         if not isinstance(replace, Node) and (
-                #             isinstance(replace, types.FunctionType)
-                #             or isinstance(replace, types.MethodType)
-                #         ):
-                #             # call function to get node
-                #             replace = replace()
-                #         node._callable_args[i] = replace
+                # replace upstream dependencies with their actual node equivalents
+                if hasattr(meth, "_nodes_to_bind"):
+                    nodes_to_bind = meth._nodes_to_bind
 
-                # # modify in place in case used elsewhere
-                # for k, arg in node._callable_kwargs.items():
-                #     if not isinstance(arg, Node):
-                #         replace = getattr(self, arg)
-                #         if not isinstance(replace, Node) and (
-                #             isinstance(replace, types.FunctionType)
-                #             or isinstance(replace, types.MethodType)
-                #         ):
-                #             # call function to get node
-                #             replace = replace()
-                #         node._callable_kwargs[k] = replace
+                    for node in nodes_to_bind:
+                        if not hasattr(self, node):
+                            raise TributaryException("Error binding dependency {} to node {} - make sure to super() after all nodes are defined".format(node, meth))
+
+                        node_to_bind = getattr(self, node)
+                        if isinstance(node_to_bind, Node):
+                            meth << getattr(self, node)                     
 
     def node(self, name, readonly=False, nullable=True, value=None):  # noqa: F811
         """method to create a lazy node attached to a graph.

--- a/tributary/lazy/node.py
+++ b/tributary/lazy/node.py
@@ -6,7 +6,7 @@ from frozendict import frozendict
 from ..base import StreamEnd, TributaryException, StreamNone, StreamRepeat
 
 # from boltons.funcutils import wraps
-from ..utils import _compare, _ismethod, _either_type, _gen_to_func
+from ..utils import _compare, _ismethod, _gen_to_func
 from .dd3 import _DagreD3Mixin
 
 ArgState = namedtuple("ArgState", ["args", "kwargs", "varargs", "varkwargs"])
@@ -59,6 +59,8 @@ class Parameter(object):
             # TODO default-as-function
             self.default = default
 
+    def __repr__(self):
+        return "Param[{}-{}-{}]".format(self.name, self.position, self.kind)
 
 class Node(_DagreD3Mixin):
     """Class to represent an operation that is lazy"""
@@ -249,6 +251,8 @@ class Node(_DagreD3Mixin):
 
         self._parameters = updated_parameters
 
+        print(self._parameters, self.upstream())
+
     def _pushDep(self, param, parameter_node):
         self.args.append(parameter_node)
         self.kwargs[param.name] = parameter_node
@@ -260,11 +264,11 @@ class Node(_DagreD3Mixin):
     def __repr__(self):
         return "{}".format(self._name)
 
-    def upstream(self, node=None):
+    def upstream(self):
         """Access list of upstream nodes"""
         return self._upstream
 
-    def downstream(self, node=None):
+    def downstream(self):
         """Access list of downstream nodes"""
         return self._downstream
 
@@ -503,34 +507,3 @@ class Node(_DagreD3Mixin):
                 value=other, name="var(" + str(other) + ")"
             )
         return self._node_op_cache[str(other)]
-
-
-@_either_type
-def node(meth, **attribute_kwargs):
-    """Convert a method into a lazy node
-    Since `self` is not defined at the point of method creation, you can pass in
-    extra kwargs which represent attributes of the future `self`. These will be
-    converted to node args during instantiation
-    The format is:
-        @node(my_existing_attr_as_an_arg="_attribute_name"):
-        def my_method(self):
-            pass
-    this will be converted into a graph of the form:
-        self._attribute_name -> my_method
-    e.g. as if self._attribute_name was passed as an argument to my_method, and converted to a node in the usual manner
-    """
-
-    # TODO attribute kwargs into nodes
-    new_node = Node(value=meth)
-    if new_node._callable_is_method:
-        ret = lambda self, *args, **kwargs: new_node._bind(  # noqa: E731
-            self, *args, **kwargs
-        )
-    else:
-        ret = lambda *args, **kwargs: new_node._bind(  # noqa: E731
-            None, *args, **kwargs
-        )
-
-    ret._node_wrapper = new_node
-    # ret = wraps(meth)(ret)
-    return ret

--- a/tributary/lazy/node.py
+++ b/tributary/lazy/node.py
@@ -62,6 +62,7 @@ class Parameter(object):
     def __repr__(self):
         return "Param[{}-{}-{}]".format(self.name, self.position, self.kind)
 
+
 class Node(_DagreD3Mixin):
     """Class to represent an operation that is lazy"""
 
@@ -176,6 +177,9 @@ class Node(_DagreD3Mixin):
         self.args = []
         self.kwargs = {}
 
+        # map from node back to corresponding param
+        self.node_to_param = {}
+
         # we may need to update parameters for dynamic args/kwargs, so we will modify this and set it at the end
         updated_parameters = self._parameters.copy()
 
@@ -251,11 +255,17 @@ class Node(_DagreD3Mixin):
 
         self._parameters = updated_parameters
 
-        print(self._parameters, self.upstream())
-
     def _pushDep(self, param, parameter_node):
+        # add to param map
+        self.node_to_param[parameter_node] = param
+
+        # add to args lookup
         self.args.append(parameter_node)
+
+        # add to kwargs lookup
         self.kwargs[param.name] = parameter_node
+
+        # add to upstream
         self << parameter_node
 
     # ***********************

--- a/tributary/parser/__init__.py
+++ b/tributary/parser/__init__.py
@@ -82,7 +82,12 @@ class Transformer(ast.NodeTransformer):
             # then replace with argument
             #
             # Name(id='blerg', ctx=Load())
-            return ast.Name(id=node.func.attr, ctx=ast.Load(), lineno=node.func.lineno, col_offset=node.func.col_offset)
+            return ast.Name(
+                id=node.func.attr,
+                ctx=ast.Load(),
+                lineno=node.func.lineno,
+                col_offset=node.func.col_offset,
+            )
         elif isClassAttribute(node) and isinstance(node, ast.Attribute):
             # Attribute(
             #     value=Name(id='self', ctx=Load()),
@@ -92,7 +97,12 @@ class Transformer(ast.NodeTransformer):
             # then replace with argument
             #
             # Name(id='blerg', ctx=Load())
-            name = ast.Name(id=node.attr, ctx=ast.Load(), lineno=node.lineno, col_offset=node.col_offset)
+            name = ast.Name(
+                id=node.attr,
+                ctx=ast.Load(),
+                lineno=node.lineno,
+                col_offset=node.col_offset,
+            )
             self._transformed_to_nodes.append(name)
             return name
         elif isinstance(node, ast.Call) and node.func in self._transformed_to_nodes:

--- a/tributary/parser/__init__.py
+++ b/tributary/parser/__init__.py
@@ -1,0 +1,106 @@
+import ast
+import inspect
+import textwrap
+
+
+def parseASTForMethod(meth):
+    source = inspect.getsource(meth)
+    dedented_source = textwrap.dedent(source)
+    mod = ast.parse(dedented_source)
+    return mod.body[0], mod
+
+
+def pprintAst(astNode):
+    print(ast.dump(astNode, indent=4))
+
+
+def pprintCode(astNode):
+    print(ast.unparse(astNode))
+
+
+def isClassAttribute(node):
+    # self.aNode()
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.value.id == "self"
+    ):
+        return node.func.attr
+    # self.aNode
+    elif isinstance(node, ast.Attribute) and node.value.id == "self":
+        return node.attr
+
+
+def getClassAttributesUsedInMethod(root):
+    attribute_deps = set()
+    for node in ast.walk(root):
+        attr = isClassAttribute(node)
+        if attr:
+            attribute_deps.add(attr)
+    return attribute_deps
+
+
+# append attribute args to method definition
+def addAttributeDepsToMethodSignature(root, attribute_deps):
+    for attribute_dep in attribute_deps:
+        append = True
+
+        for meth_arg in root.args.args:
+            if meth_arg.arg == attribute_dep:
+                append = False
+
+        if append:
+            if root.args.args:
+                # use first one
+                lineno = root.args.args[0].lineno
+            else:
+                # use definition
+                lineno = root.lineno
+
+            # set lineno to as close as we can, but can't do col_offset really
+            root.args.args.append(ast.arg(attribute_dep, lineno=lineno, col_offset=0))
+
+
+class Transformer(ast.NodeTransformer):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._transformed_to_nodes = []
+
+    def generic_visit(self, node):
+        # Need to call super() in any case to visit child nodes of the current one.
+        super().generic_visit(node)
+
+        if isClassAttribute(node) and isinstance(node, ast.Call):
+            # Call(
+            #     func=Attribute(
+            #         value=Name(id='self', ctx=Load()),
+            #         attr='func2',
+            #         ctx=Load()),
+            #     args=[],
+            #     keywords=[])
+            #
+            # then replace with argument
+            #
+            # Name(id='blerg', ctx=Load())
+            return ast.Name(id=node.func.attr, ctx=ast.Load(), lineno=node.func.lineno, col_offset=node.func.col_offset)
+        elif isClassAttribute(node) and isinstance(node, ast.Attribute):
+            # Attribute(
+            #     value=Name(id='self', ctx=Load()),
+            #     attr='func2',
+            #     ctx=Load())
+            #
+            # then replace with argument
+            #
+            # Name(id='blerg', ctx=Load())
+            name = ast.Name(id=node.attr, ctx=ast.Load(), lineno=node.lineno, col_offset=node.col_offset)
+            self._transformed_to_nodes.append(name)
+            return name
+        elif isinstance(node, ast.Call) and node.func in self._transformed_to_nodes:
+            # if we transformed the inner attribute but its still being called, e.g.
+            # def func1(self, func2):
+            #    return func2() + 1
+
+            # in this case, just promote the inner name to replace the call
+            return node.func
+
+        return node

--- a/tributary/symbolic/__init__.py
+++ b/tributary/symbolic/__init__.py
@@ -74,6 +74,7 @@ def construct_lazy(expr, modules=None):
             self._nodes = [getattr(self, n) for n in names]
             self._function = lambdify(syms, expr, modules=modules)
             self._expr = expr
+            super().__init__()
 
         @tl.node
         def evaluate(self):

--- a/tributary/tests/lazy/test_graph_class_lazy.py
+++ b/tributary/tests/lazy/test_graph_class_lazy.py
@@ -41,30 +41,31 @@ class Func4(t.LazyGraph):
 
 
 class Func5(t.LazyGraph):
+    def __init__(self):
+        self.x = self.node(name="x", value=None)
+        super().__init__()
+
     @t.node()
     def z(self):
         return self.x | self.y()
 
-    @t.node()
+    @t.node
     def y(self):
         return 10
 
     def reset(self):
         self.x = None
 
-    def __init__(self):
-        self.x = self.node(name="x", value=None)
-
 
 class TestLazy:
     # FIXME
-    # def test_misc(self):
-    #     f4 = Func4()
-    #     z = f4.func1()
-    #     assert isinstance(z, float) and z >= 1
-    #     assert f4.func1.print()
-    #     assert f4.func1.graph()
-    #     assert f4.func1.graphviz()
+    def test_misc(self):
+        f4 = Func4()
+        z = f4.func1()
+        assert isinstance(z, float) and z >= 1
+        assert f4.func1.print()
+        assert f4.func1.graph()
+        assert f4.func1.graphviz()
 
     def test_lazy_default_func_arg(self):
         def func(val, prev_val=0):


### PR DESCRIPTION
This is the first of several changes that increase the usability of tributary at the cost of additional intrusiveness.

This PR lets tributary automatically convert class attributes and methods to tributary nodes, starting with lazy graphs. To do so, we read the AST of a method and convert `self` accesses to tributary nodes, similar to how we convert standalone function arguments to nodes. This will let you build full lazy graphs into custom classes.

As an example, given a class like this:

```
class SomeLazyClass(t.LazyGraph):
    def __init__(self):
        super().__init__()
        self.x = self.node(name="x", value=None)

    @t.node()
    def z(self):
        return self.x() | self.y()

    @t.node()
    def y(self):
        return 10
```

`self.x` is created directly, as is currently possible for tributary nodes.
`self.y()` is created as an independent method with no upstream dependencies, as is also currently possible.
`self.z()` is created as an independent method, and the dependency graph on `self.x` and `self.y` is built by parsing the AST of the `z` method. 